### PR TITLE
Add AI raising and removal behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,15 @@ python3 pylos/play.py
 
 Follow the on-screen instructions to place spheres, raise them onto higher
 levels and remove your own pieces when allowed.
+
+You can also challenge the trained AI. After training is complete run:
+
+```bash
+python3 pylos/play_ai.py --model pylos/out/model.pth --first
+```
+
+Remove `--first` if you want the AI to move first. Use `--search` to adjust the
+number of simulations used by the AI during its turn.
+The command interface matches `play.py`, so you can use the same `place` and `raise`
+commands when it's your turn. The AI will also attempt raise moves on its own and
+automatically remove its pieces after completing a square or line.

--- a/pylos/game.py
+++ b/pylos/game.py
@@ -175,6 +175,25 @@ class PylosGame:
                                             return True
         return False
 
+    def get_legal_raises(self):
+        """Return a list of valid raise moves for the current player.
+
+        Each element is a tuple (sl, sr, sc, dl, dr, dc).
+        """
+        raises = []
+        for sl, layer in enumerate(self.board[:-1]):
+            for sr in range(layer.shape[0]):
+                for sc in range(layer.shape[1]):
+                    if layer[sr, sc] == self.turn and not self.piece_has_top(sl, sr, sc):
+                        for dl in range(sl + 1, len(self.board)):
+                            size = self.board[dl].shape[0]
+                            for dr in range(size):
+                                for dc in range(size):
+                                    if self.board[dl][dr, dc] == 0 and self.is_supported(dl, dr, dc):
+                                        if dl - 1 >= sl:
+                                            raises.append((sl, sr, sc, dl, dr, dc))
+        return raises
+
     # -----------------------------------------------------------
     # AlphaZero training helpers
     def get_legal_actions(self):

--- a/pylos/play_ai.py
+++ b/pylos/play_ai.py
@@ -1,0 +1,138 @@
+import argparse
+import os
+import sys
+import torch
+
+sys.path.append(os.getcwd())
+
+from agents import AlphaZeroAgent
+from game import PylosGame
+from mcts import play
+from models import LinearNetwork
+
+
+def parse_coords(text):
+    parts = text.split(',')
+    if len(parts) != 3:
+        raise ValueError
+    return tuple(int(p) for p in parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Play Pylos against a trained AI")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="pylos/out/model.pth",
+        help="Path to the trained model",
+    )
+    parser.add_argument(
+        "--search",
+        type=int,
+        default=32,
+        help="Number of MCTS simulations for the AI",
+    )
+    parser.add_argument(
+        "--first",
+        action="store_true",
+        help="Play as white and make the first move",
+    )
+    args = parser.parse_args()
+
+    game = PylosGame()
+
+    model = LinearNetwork(game.observation_shape, game.action_space)
+    model.load_state_dict(torch.load(args.model, map_location=model.device))
+    agent = AlphaZeroAgent(model)
+
+    human_turn = 1 if args.first else -1
+
+    while True:
+        print(game)
+        if game.top_filled():
+            winner = "White" if game.board[-1][0, 0] == 1 else "Black"
+            print(f"{winner} wins by completing the pyramid!")
+            break
+        if not game.has_move():
+            winner = "White" if game.turn == -1 else "Black"
+            print(f"{winner} wins. Opponent has no moves left.")
+            break
+        player = "White" if game.turn == 1 else "Black"
+        if game.turn == human_turn:
+            print(f"{player}'s turn. Reserve pieces: {game.reserves[game.turn]}")
+            cmd = input("Enter command (place l,r,c | raise sl,sr,sc dl,dr,dc): ").strip()
+            if not cmd:
+                continue
+            if cmd.lower() == "quit":
+                break
+            tokens = cmd.replace("->", " ").replace("|", " ").split()
+            try:
+                if tokens[0] == "place" and len(tokens) == 2:
+                    lvl, r, c = parse_coords(tokens[1])
+                    if not game.place(lvl, r, c):
+                        print("Invalid placement")
+                        continue
+                elif tokens[0] == "raise" and len(tokens) == 3:
+                    sl, sr, sc = parse_coords(tokens[1])
+                    dl, dr, dc = parse_coords(tokens[2])
+                    if not game.raise_piece(sl, sr, sc, dl, dr, dc):
+                        print("Invalid raise move")
+                        continue
+                else:
+                    print("Unrecognized command")
+                    continue
+            except Exception:
+                print("Invalid input format")
+                continue
+        else:
+            raise_moves = game.get_legal_raises()
+            if raise_moves:
+                sl, sr, sc, dl, dr, dc = raise_moves[0]
+                print(f"AI raises: {sl},{sr},{sc} -> {dl},{dr},{dc}")
+                game.raise_piece(sl, sr, sc, dl, dr, dc)
+            else:
+                action = play(game, agent, args.search, c_puct=1.5)
+                lvl, r, c = game.index_to_coords[action]
+                print(f"AI plays: {lvl},{r},{c}")
+                game.place(lvl, r, c)
+
+        if game.check_for_removal():
+            if game.turn == human_turn:
+                for i in range(2):
+                    rem = input(
+                        f"You may remove piece {i + 1} (level,row,col) or press Enter to skip: "
+                    ).strip()
+                    if not rem:
+                        break
+                    try:
+                        rl, rr, rc = parse_coords(rem)
+                        if not game.remove(rl, rr, rc):
+                            print("Cannot remove that piece")
+                            continue
+                    except Exception:
+                        print("Invalid coordinates")
+                        continue
+            else:
+                removed = 0
+                for lvl, layer in enumerate(game.board):
+                    for r in range(layer.shape[0]):
+                        for c in range(layer.shape[1]):
+                            if removed >= 2:
+                                break
+                            if (
+                                layer[r, c] == game.turn
+                                and not game.piece_has_top(lvl, r, c)
+                            ):
+                                game.remove(lvl, r, c)
+                                print(f"AI removes: {lvl},{r},{c}")
+                                removed += 1
+                        if removed >= 2:
+                            break
+                    if removed >= 2:
+                        break
+
+        game.turn *= -1
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- teach PylosGame to enumerate legal raise moves
- let the AI raise pieces and remove its own spheres when possible
- clarify README on AI raising/removal

## Testing
- `python3 -m py_compile pylos/play_ai.py pylos/game.py pylos/train.py`
- `ruff check .`
- `WANDB_MODE=dryrun python3 pylos/train.py` *(interrupted after start)*
- `python3 pylos/play_ai.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6840a989f36883228ef8c33faf229d8c